### PR TITLE
US318 fix - alert dialog closed when render my project

### DIFF
--- a/src/pages/proyects/ProjectPage.js
+++ b/src/pages/proyects/ProjectPage.js
@@ -9,7 +9,7 @@ import { withSnackbar } from "../../components/SnackBarHOC";
 function ProjectPage(props) {
   const { showMessage } = props;
   const [project, setProject] = useState();
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(false);
 
   const handleClose = () => {
     setOpen(!open);


### PR DESCRIPTION
Como usuario registrado quiero poder ver el listado de mis proyectos para poder administrarlos

Criterios de aceptacion:

    Loader mientras se cargan los proyectos
    Mensade de: "No hay proyectos" si el BE retorna un arreglo vacio
    Mensaje de error si hay algun problema con el BE a la hora de buscar los proyectos
    Route: /my-projects
    Redirect a /my-projects/<id> cuando se hace click sobre una card
    MaterialUI

