### PR TITLE
Uptade Visibility in Modify Discussion

### DIFF
--- a/src/components/DiscussionsList.js
+++ b/src/components/DiscussionsList.js
@@ -204,41 +204,50 @@ function DiscussionsList(props) {
                           </TextLink>
                         </Grid>
                       )}
-                      {((isUserLoggedIn() &&
-                        user &&
-                        user?.id === discussion?.owner?.id) ||
-                        (user && user?.id === discussion.project.owner.id)) && (
-                        <Grid>
-                          <IconButton
-                            aria-label="delete"
-                            color="primary"
-                            size="small"
-                            onClick={handleClickOpenDelete}
-                          >
-                            <DeleteIcon />
-                          </IconButton>
-                          <DeleteDiscussion
-                            open={openDelete}
-                            handleClose={handleCloseDelete}
-                            id={discussion.id}
-                            fetchProject={fetchProject}
-                          />
-                          <IconButton
-                            aria-label="edit"
-                            color="primary"
-                            size="small"
-                            onClick={handleClickOpenUpdate}
-                          >
-                            <EditIcon />
-                          </IconButton>
-                          <ModifyDiscussion
-                            open={openUpdate}
-                            handleClose={handleCloseUpdate}
-                            id={discussion?.id}
-                            fetchProject={fetchProject}
-                          />
-                        </Grid>
-                      )}
+                      <Grid container direction="row">
+                        {((isUserLoggedIn() &&
+                          user &&
+                          user?.id === discussion?.owner?.id) ||
+                          (user &&
+                            user?.id === discussion.project.owner.id)) && (
+                          <Grid>
+                            <IconButton
+                              aria-label="delete"
+                              color="primary"
+                              size="small"
+                              onClick={handleClickOpenDelete}
+                            >
+                              <DeleteIcon />
+                            </IconButton>
+                            <DeleteDiscussion
+                              open={openDelete}
+                              handleClose={handleCloseDelete}
+                              id={discussion.id}
+                              fetchProject={fetchProject}
+                            />
+                          </Grid>
+                        )}
+                        {isUserLoggedIn() &&
+                          user &&
+                          user?.id === discussion?.owner?.id && (
+                            <Grid>
+                              <IconButton
+                                aria-label="edit"
+                                color="primary"
+                                size="small"
+                                onClick={handleClickOpenUpdate}
+                              >
+                                <EditIcon />
+                              </IconButton>
+                              <ModifyDiscussion
+                                open={openUpdate}
+                                handleClose={handleCloseUpdate}
+                                id={discussion?.id}
+                                fetchProject={fetchProject}
+                              />
+                            </Grid>
+                          )}
+                      </Grid>
                     </Box>
                   </CardContent>
                 </CardDiscussion>


### PR DESCRIPTION
Now, the owner of the proyect can delete others discussions but not modify them. 

The "permissions" are like this (always if they are logged in): 

New Discussion: 
Proyect owner and collaborators. 

Delete Discussion: 
Discussion owner and proyect owner. 

Update Discussion: 
Discussion owner. 
